### PR TITLE
gdb/cuda: add SASS listing breakpoints

### DIFF
--- a/gdb/breakpoint.c
+++ b/gdb/breakpoint.c
@@ -112,6 +112,8 @@ static void autostep_command (const char *, int);
 static bool is_autostep (const struct breakpoint *bpt);
 static void autosteps_info (const char *, int);
 static void delete_cuda_uvm_breakpoint (void);
+static bool cuda_sass_break_command_p (const char *);
+static void cuda_sass_break_command_1 (const char *, int, int);
 #endif
 /* Prototypes for local functions.  */
 
@@ -362,6 +364,58 @@ struct ordinary_breakpoint : public code_breakpoint
   void print_mention () const override;
   void print_recreate (struct ui_file *fp) const override;
 };
+
+#ifdef NVIDIA_CUDA_GDB
+static const char cuda_sass_break_prefix[] = "-sass";
+
+enum cuda_sass_breakpoint_selector_kind
+{
+  cuda_sass_selector_none = 0,
+  cuda_sass_selector_instruction_number,
+  cuda_sass_selector_offset
+};
+
+struct cuda_sass_breakpoint : public ordinary_breakpoint
+{
+  cuda_sass_breakpoint (
+      struct gdbarch *gdbarch, std::string kernel,
+      enum cuda_sass_breakpoint_selector_kind selector_kind,
+      uint64_t selector_value, std::string location,
+      enum bpdisp disposition_, int enabled_)
+      : ordinary_breakpoint (gdbarch, bp_breakpoint),
+	m_kernel (std::move (kernel)),
+	m_selector_kind (selector_kind),
+	m_selector_value (selector_value),
+	m_location (std::move (location))
+  {
+    disposition = disposition_;
+    enable_state = enabled_ ? bp_enabled : bp_disabled;
+    condition_not_parsed = 1;
+
+    const char *locspec_arg = m_kernel.c_str ();
+    locspec = new_linespec_location_spec (&locspec_arg,
+					  symbol_name_match_type::WILD);
+    locspec->set_string (std::string (cuda_sass_break_prefix) + " "
+			 + m_location);
+  }
+
+  void re_set (program_space *filter_pspace) override;
+  void resolve_initial_locations ()
+  {
+    resolve_locations (nullptr, false);
+  }
+
+private:
+  bool resolve_locations (program_space *filter_pspace, bool notify);
+  bool add_location_for_module (cuda_module *module);
+
+  std::string m_kernel;
+  enum cuda_sass_breakpoint_selector_kind m_selector_kind
+      = cuda_sass_selector_none;
+  uint64_t m_selector_value = 0;
+  std::string m_location;
+};
+#endif
 
 /* Internal breakpoints.  These typically have a lifetime the same as
    the program, and they end up installed on the breakpoint chain with
@@ -10346,9 +10400,135 @@ create_breakpoint (struct gdbarch *gdbarch,
    and if breakpoint is temporary, using BP_HARDWARE_FLAG
    and BP_TEMPFLAG.  */
 
+#ifdef NVIDIA_CUDA_GDB
+static bool
+cuda_sass_break_command_p (const char *arg)
+{
+  if (arg == nullptr)
+    return false;
+
+  arg = skip_spaces (arg);
+  const size_t prefix_len = strlen (cuda_sass_break_prefix);
+  return (strncmp (arg, cuda_sass_break_prefix, prefix_len) == 0
+	  && (arg[prefix_len] == '\0' || isspace (arg[prefix_len])));
+}
+
+static bool
+cuda_sass_parse_uint64 (const std::string &str, uint64_t *value)
+{
+  if (str.empty ())
+    return false;
+
+  char *end = nullptr;
+  errno = 0;
+  unsigned long long parsed = strtoull (str.c_str (), &end, 0);
+  if (errno != 0 || end == nullptr || *end != '\0')
+    return false;
+
+  *value = parsed;
+  return true;
+}
+
+static void
+cuda_sass_parse_location (const std::string &location,
+			  std::string &kernel_name,
+			  enum cuda_sass_breakpoint_selector_kind &kind,
+			  uint64_t &value)
+{
+  const auto plus = location.rfind ('+');
+  const auto colon = location.rfind (':');
+
+  if (plus != std::string::npos
+      && (colon == std::string::npos || plus > colon))
+    {
+      kernel_name = location.substr (0, plus);
+      const std::string offset_str = location.substr (plus + 1);
+      if (kernel_name.empty ()
+	  || !cuda_sass_parse_uint64 (offset_str, &value))
+	error (_ ("Invalid SASS offset location '%s'."),
+	       location.c_str ());
+
+      kind = cuda_sass_selector_offset;
+      return;
+    }
+
+  if (colon != std::string::npos)
+    {
+      kernel_name = location.substr (0, colon);
+      const std::string number_str = location.substr (colon + 1);
+      if (kernel_name.empty ()
+	  || !cuda_sass_parse_uint64 (number_str, &value)
+	  || value == 0 || value > UINT32_MAX)
+	error (_ ("Invalid SASS instruction location '%s'."),
+	       location.c_str ());
+
+      kind = cuda_sass_selector_instruction_number;
+      return;
+    }
+
+  error (_ ("SASS breakpoint location must be KERNEL:NUMBER or "
+	    "KERNEL+OFFSET."));
+}
+
+static void
+cuda_sass_break_command_1 (const char *arg, int flag, int from_tty)
+{
+  if ((flag & BP_HARDWAREFLAG) != 0)
+    error (_ ("SASS breakpoints do not support hardware breakpoint "
+	      "commands."));
+
+  const int tempflag = flag & BP_TEMPFLAG;
+  const size_t prefix_len = strlen (cuda_sass_break_prefix);
+
+  arg = skip_spaces (arg);
+  arg += prefix_len;
+  arg = skip_spaces (arg);
+  if (*arg == '\0')
+    error (_ ("Missing SASS breakpoint location."));
+
+  const char *location_start = arg;
+  while (*arg != '\0' && !isspace (*arg))
+    ++arg;
+
+  std::string location (location_start, arg - location_start);
+  arg = skip_spaces (arg);
+  if (*arg != '\0')
+    error (_ ("Extra arguments are not supported for SASS "
+	      "breakpoints."));
+
+  std::string kernel_name;
+  enum cuda_sass_breakpoint_selector_kind selector_kind
+      = cuda_sass_selector_none;
+  uint64_t selector_value = 0;
+  cuda_sass_parse_location (location, kernel_name, selector_kind,
+			    selector_value);
+
+  std::unique_ptr<cuda_sass_breakpoint> b (new cuda_sass_breakpoint (
+      get_current_arch (), std::move (kernel_name), selector_kind,
+      selector_value, location, tempflag ? disp_del : disp_donttouch,
+      1 /* enabled */));
+
+  cuda_sass_breakpoint *raw_b = b.get ();
+  breakpoint *installed = add_to_breakpoint_chain (std::move (b));
+  set_breakpoint_number (0, installed);
+  raw_b->resolve_initial_locations ();
+  mention (installed);
+  notify_breakpoint_created (installed);
+  update_global_location_list (UGLL_MAY_INSERT);
+}
+#endif
+
 static void
 break_command_1 (const char *arg, int flag, int from_tty)
 {
+#ifdef NVIDIA_CUDA_GDB
+  if (cuda_sass_break_command_p (arg))
+    {
+      cuda_sass_break_command_1 (arg, flag, from_tty);
+      return;
+    }
+#endif
+
   int tempflag = flag & BP_TEMPFLAG;
   enum bptype type_wanted = (flag & BP_HARDWAREFLAG
 			     ? bp_hardware_breakpoint
@@ -14269,6 +14449,126 @@ breakpoint::steal_locations (program_space *pspace)
   return ret;
 }
 
+#ifdef NVIDIA_CUDA_GDB
+bool
+cuda_sass_breakpoint::add_location_for_module (cuda_module *module)
+{
+  gdb_assert (module != nullptr);
+  gdb_assert (module->loaded ());
+
+  auto matches = cuda_sass_find_function_symbols (module, m_kernel);
+  if (matches.empty ())
+    return false;
+
+  if (matches.size () > 1)
+    {
+      warning (_ ("SASS breakpoint %d is ambiguous in module 0x%llx; "
+		  "use a mangled kernel/function name."),
+	       number, (unsigned long long) module->id ());
+      return false;
+    }
+
+  const auto &match = matches.front ();
+  std::optional<cuda_sass_instruction_record> record;
+  switch (m_selector_kind)
+    {
+    case cuda_sass_selector_instruction_number:
+      record = module->disassembler ()->get_instruction_by_number (
+	  match.linkage_name, match.entry_pc, (uint32_t) m_selector_value);
+      break;
+    case cuda_sass_selector_offset:
+      record = module->disassembler ()->get_instruction_by_offset (
+	  match.linkage_name, match.entry_pc, m_selector_value);
+      break;
+    default:
+      break;
+    }
+
+  if (!record.has_value ())
+    {
+      const char *location
+	  = locspec != nullptr ? locspec->to_string () : nullptr;
+      if (location == nullptr)
+	location = "<unknown>";
+      warning (_ ("SASS breakpoint %d could not resolve %s in "
+		  "module 0x%llx."),
+	       number, location,
+	       (unsigned long long) module->id ());
+      return false;
+    }
+
+  CORE_ADDR addr = record->pc;
+  if (!cuda_is_device_code_address (addr))
+    return false;
+
+  struct gdbarch *arch = cuda_get_gdbarch ();
+  if (arch == nullptr)
+    return false;
+
+  program_space *module_pspace = module->objfile ()->pspace ();
+  scoped_restore_current_pspace_and_thread restore_pspace_thread;
+  switch_to_program_space_and_thread (module_pspace);
+
+  addr = adjust_breakpoint_address (arch, addr, type, module_pspace);
+
+  for (bp_location &loc : locations ())
+    if (loc.pspace == module_pspace
+	&& (loc.address == addr || loc.requested_address == addr))
+      return false;
+
+  symtab_and_line sal = find_pc_line (addr, 0);
+  sal.pc = addr;
+  sal.section = find_pc_overlay (addr);
+  sal.pspace = module_pspace;
+  sal.explicit_pc = 0;
+
+  bp_location *loc = add_location (sal);
+  loc->address = addr;
+  loc->requested_address = addr;
+  gdbarch = arch;
+
+  cuda_trace_breakpoint (
+      "added SASS breakpoint location: breakpoint %d address 0x%llx "
+      "module 0x%llx",
+      number, (unsigned long long) addr, (unsigned long long) module->id ());
+
+  return true;
+}
+
+bool
+cuda_sass_breakpoint::resolve_locations (program_space *filter_pspace,
+					 bool notify)
+{
+  bp_location_list existing_locations = steal_locations (filter_pspace);
+  bool resolved = false;
+
+  for (auto &iter : cuda_state::modules ())
+    {
+      cuda_module *module = iter.second.get ();
+      if (module == nullptr || !module->loaded ()
+	  || module->objfile () == nullptr)
+	continue;
+
+      if (filter_pspace != nullptr
+	  && module->objfile ()->pspace () != filter_pspace)
+	continue;
+
+      resolved |= add_location_for_module (module);
+    }
+
+  if (notify && !locations_are_equal (existing_locations, locations ()))
+    notify_breakpoint_modified (this);
+
+  return resolved;
+}
+
+void
+cuda_sass_breakpoint::re_set (program_space *filter_pspace)
+{
+  resolve_locations (filter_pspace, true);
+}
+#endif
+
 /* Create new breakpoint locations for B (a hardware or software
    breakpoint) based on SALS and SALS_END.  If SALS_END.NELTS is not
    zero, then B is a ranged breakpoint.  Only recreates locations for
@@ -16135,6 +16435,16 @@ specified name as a complete fully-qualified name instead."
    COMMAND should be a string constant containing the name of the
    command.  */
 
+#ifdef NVIDIA_CUDA_GDB
+#define CUDA_SASS_BREAK_ARGS_HELP \
+"SASS locations are selected with `-sass KERNEL:NUMBER' or\n\
+`-sass KERNEL+OFFSET'.  NUMBER is the one-based instruction number\n\
+shown by `sass KERNEL'; OFFSET is a SASS offset in the function.\n\
+\n"
+#else
+#define CUDA_SASS_BREAK_ARGS_HELP ""
+#endif
+
 #define BREAK_ARGS_HELP(command) \
 command" [PROBE_MODIFIER] [LOCATION] [thread THREADNUM]\n\
 \t[-force-condition] [if CONDITION]\n\
@@ -16153,7 +16463,7 @@ CONDITION is a boolean expression.\n\
 \n\
 With the \"-force-condition\" flag, the condition is defined even when\n\
 it is invalid for all current locations.\n\
-\n" LOCATION_SPEC_HELP_STRING "\n\n\
+\n" CUDA_SASS_BREAK_ARGS_HELP LOCATION_SPEC_HELP_STRING "\n\n\
 Multiple breakpoints at one place are permitted, and useful if their\n\
 conditions are different.\n\
 \n\

--- a/gdb/cuda/cuda-asm.c
+++ b/gdb/cuda/cuda-asm.c
@@ -225,6 +225,97 @@ static void inline map_insert_or_assign (M &map, const K &key, V &&value)
     }
 }
 
+static bool
+cuda_sass_msymbol_is_text (minimal_symbol *msym)
+{
+  switch (msym->type ())
+    {
+    case mst_text:
+    case mst_text_gnu_ifunc:
+    case mst_file_text:
+      return true;
+    default:
+      return false;
+    }
+}
+
+static bool
+cuda_sass_symbol_name_matches (minimal_symbol *msym,
+			       const std::string &function_name)
+{
+  const char *linkage_name = msym->linkage_name ();
+  if (linkage_name != nullptr && function_name == linkage_name)
+    return true;
+
+  const char *natural_name = msym->natural_name ();
+  if (natural_name != nullptr)
+    {
+      std::string natural (natural_name);
+      if (function_name == natural)
+	return true;
+
+      if (startswith (natural.c_str (), function_name.c_str ()))
+	{
+	  const char next = natural[function_name.size ()];
+	  if (next == '(' || next == '<')
+	    return true;
+	}
+
+      const std::string qualified_suffix = "::" + function_name;
+      const auto pos = natural.rfind (qualified_suffix);
+      if (pos != std::string::npos)
+	{
+	  const size_t end = pos + qualified_suffix.size ();
+	  if (end == natural.size () || natural[end] == '('
+	      || natural[end] == '<')
+	    return true;
+	}
+    }
+
+  return false;
+}
+
+std::vector<cuda_sass_function_symbol>
+cuda_sass_find_function_symbols (cuda_module *module,
+				 const std::string &function_name)
+{
+  std::vector<cuda_sass_function_symbol> matches;
+
+  if (module == nullptr || !module->loaded () || module->objfile () == nullptr)
+    return matches;
+
+  for (minimal_symbol *msym : module->objfile ()->msymbols ())
+    {
+      if (!cuda_sass_msymbol_is_text (msym))
+	continue;
+
+      if (!cuda_sass_symbol_name_matches (msym, function_name))
+	continue;
+
+      CORE_ADDR entry_pc = msym->value_address (module->objfile ());
+      const char *linkage_name = msym->linkage_name ();
+      const char *natural_name = msym->natural_name ();
+      if (entry_pc == 0 || linkage_name == nullptr)
+	continue;
+
+      bool duplicate = false;
+      for (const auto &match : matches)
+	if (match.entry_pc == entry_pc && match.linkage_name == linkage_name)
+	  {
+	    duplicate = true;
+	    break;
+	  }
+      if (duplicate)
+	continue;
+
+      matches.push_back ({ linkage_name,
+			   natural_name != nullptr ? natural_name : linkage_name,
+			   entry_pc });
+    }
+
+  return matches;
+}
+
 std::optional<cuda_instruction>
 cuda_module_disassembly_cache::disassemble_instruction (uint64_t pc)
 {
@@ -293,13 +384,20 @@ cuda_module_disassembly_cache::add_function_to_cache (
     const cuda_function &function, const disassembly_source source)
 {
   uint64_t pc = function.start_address ();
+  uint32_t number = 1;
+  uint64_t offset = 0;
+
   switch (source)
     {
     case disassembly_source::ELF:
+      m_elf_function_map[function.name ()].clear ();
       for (const cuda_instruction &insn : function.instructions ())
 	{
 	  map_insert_or_assign (m_elf_map, pc, cuda_instruction (insn));
+	  add_listing_record (function.name (), number, offset, pc, insn);
 	  pc += m_insn_size;
+	  offset += m_insn_size;
+	  ++number;
 	}
       break;
     case disassembly_source::DEVICE:
@@ -312,6 +410,68 @@ cuda_module_disassembly_cache::add_function_to_cache (
     default:
       error ("Unknown disassembly source");
     }
+}
+
+void
+cuda_module_disassembly_cache::add_listing_record (
+    const std::string &function_name, const uint32_t number,
+    const uint64_t offset, const CORE_ADDR pc,
+    const cuda_instruction &instruction)
+{
+  m_elf_function_map[function_name].push_back (
+      { number, offset, pc, instruction.to_string () });
+}
+
+bool
+cuda_module_disassembly_cache::get_function_listing (
+    const std::string &function_name, const CORE_ADDR entry_pc,
+    std::vector<cuda_sass_instruction_record> &listing)
+{
+  listing.clear ();
+
+  if (entry_pc == 0)
+    return false;
+
+  disassemble_instruction (entry_pc, disassembly_source::ELF);
+
+  auto iter = m_elf_function_map.find (function_name);
+  if (iter == m_elf_function_map.end () || iter->second.empty ())
+    return false;
+
+  listing = iter->second;
+  return true;
+}
+
+std::optional<cuda_sass_instruction_record>
+cuda_module_disassembly_cache::get_instruction_by_number (
+    const std::string &function_name, const CORE_ADDR entry_pc,
+    const uint32_t number)
+{
+  std::vector<cuda_sass_instruction_record> listing;
+  if (!get_function_listing (function_name, entry_pc, listing))
+    return std::optional<cuda_sass_instruction_record> ();
+
+  for (const auto &record : listing)
+    if (record.number == number)
+      return record;
+
+  return std::optional<cuda_sass_instruction_record> ();
+}
+
+std::optional<cuda_sass_instruction_record>
+cuda_module_disassembly_cache::get_instruction_by_offset (
+    const std::string &function_name, const CORE_ADDR entry_pc,
+    const uint64_t offset)
+{
+  std::vector<cuda_sass_instruction_record> listing;
+  if (!get_function_listing (function_name, entry_pc, listing))
+    return std::optional<cuda_sass_instruction_record> ();
+
+  for (const auto &record : listing)
+    if (record.offset == offset)
+      return record;
+
+  return std::optional<cuda_sass_instruction_record> ();
 }
 
 class posix_spawn_file_actions
@@ -692,7 +852,8 @@ cuda_module_disassembly_cache::populate_from_elf_image (const uint64_t pc)
 {
   // If we couldn't find the cubin, we can't disassemble from the elf
   // image.
-  const auto module = cuda_state::find_module_by_address (pc);
+  const auto module = m_module != nullptr ? m_module
+					  : cuda_state::find_module_by_address (pc);
   if (!module)
     {
       warning ("Could not find cubin to disassemble for pc 0x%lx", pc);
@@ -1021,6 +1182,8 @@ cuda_module_disassembly_cache::parse_disasm_output (const int fd,
   std::string current_func;
   std::string current_line;
   std::string current_section;
+  std::string active_func;
+  uint32_t active_insn_number = 0;
   while (true)
     {
       uint64_t pc = 0;
@@ -1040,6 +1203,10 @@ cuda_module_disassembly_cache::parse_disasm_output (const int fd,
 	case disassembler_line_type::function_header:
 	  if (!current_func.empty ())
 	    {
+	      active_func = current_func;
+	      active_insn_number = 0;
+	      m_elf_function_map[active_func].clear ();
+
 	      cuda_trace_domain (CUDA_TRACE_DISASSEMBLER,
 				 "function header: %s", current_func.c_str ());
 	      /* Lookup the symbol to get the entry_pc value from the bound
@@ -1129,8 +1296,12 @@ cuda_module_disassembly_cache::parse_disasm_output (const int fd,
 	      pc = entry_pc + current_offset;
 
 	      /* insert the disassembled instruction into the map */
+	      cuda_instruction instruction (current_insn);
 	      map_insert_or_assign (m_elf_map, pc,
-				    cuda_instruction (current_insn));
+				    cuda_instruction (instruction));
+	      if (!active_func.empty ())
+		add_listing_record (active_func, ++active_insn_number,
+				    current_offset, pc, instruction);
 	      last_pc = pc;
 	      cuda_trace_domain (CUDA_TRACE_DISASSEMBLER,
 				 "offset-insn: cache pc 0x%lx insn: %s", pc,
@@ -1162,7 +1333,14 @@ cuda_module_disassembly_cache::parse_disasm_output (const int fd,
 	  if (!pc)
 	    complaint (_ ("code-only line with pc of 0"));
 	  else
-	    map_insert_or_assign (m_elf_map, pc, cuda_instruction (""));
+	    {
+	      cuda_instruction instruction ("");
+	      map_insert_or_assign (m_elf_map, pc,
+				    cuda_instruction (instruction));
+	      if (!active_func.empty () && entry_pc)
+		add_listing_record (active_func, ++active_insn_number,
+				    pc - entry_pc, pc, instruction);
+	    }
 	  last_pc = pc;
 	  break;
 

--- a/gdb/cuda/cuda-asm.h
+++ b/gdb/cuda/cuda-asm.h
@@ -37,6 +37,25 @@
 
 class cuda_module;
 
+struct cuda_sass_instruction_record
+{
+  uint32_t number;
+  uint64_t offset;
+  CORE_ADDR pc;
+  std::string text;
+};
+
+struct cuda_sass_function_symbol
+{
+  std::string linkage_name;
+  std::string display_name;
+  CORE_ADDR entry_pc;
+};
+
+std::vector<cuda_sass_function_symbol>
+cuda_sass_find_function_symbols (cuda_module *module,
+				 const std::string &function_name);
+
 class cuda_instruction
 {
 public:
@@ -147,8 +166,8 @@ private:
 class cuda_module_disassembly_cache
 {
 public:
-  cuda_module_disassembly_cache (uint32_t insn_size)
-      : m_insn_size (insn_size), m_cuobjdump_json (true)
+  cuda_module_disassembly_cache (cuda_module *module, uint32_t insn_size)
+      : m_module (module), m_insn_size (insn_size), m_cuobjdump_json (true)
   {
   }
 
@@ -161,10 +180,23 @@ public:
   /* Public API */
   std::optional<cuda_instruction> disassemble_instruction (uint64_t pc);
 
+  bool get_function_listing (
+      const std::string &function_name, CORE_ADDR entry_pc,
+      std::vector<cuda_sass_instruction_record> &listing);
+
+  std::optional<cuda_sass_instruction_record>
+  get_instruction_by_number (const std::string &function_name,
+			     CORE_ADDR entry_pc, uint32_t number);
+
+  std::optional<cuda_sass_instruction_record>
+  get_instruction_by_offset (const std::string &function_name,
+			     CORE_ADDR entry_pc, uint64_t offset);
+
   inline void
   flush_elf_cache ()
   {
     m_elf_map.clear ();
+    m_elf_function_map.clear ();
   }
 
   inline void
@@ -198,6 +230,11 @@ private:
   std::optional<cuda_instruction>
   cache_lookup (uint64_t pc, disassembly_source source) const;
 
+  void add_listing_record (const std::string &function_name,
+			   uint32_t number, uint64_t offset, CORE_ADDR pc,
+			   const cuda_instruction &instruction);
+
+  cuda_module *m_module;
   uint32_t m_insn_size;
   /* Set to false if cuobjdump doesn't support -json */
   bool m_cuobjdump_json;
@@ -205,6 +242,10 @@ private:
   /* Holder for pc->insn mappings from the cubin/ELF file.
      These are flushed at the end of LFL event processing. */
   std::unordered_map<uint64_t, cuda_instruction> m_elf_map;
+
+  std::unordered_map<std::string,
+		     std::vector<cuda_sass_instruction_record>>
+      m_elf_function_map;
 
   /* Holder for pc->insn mappings from the device.
      These are flushed at the end of LFL event processing. */

--- a/gdb/cuda/cuda-commands.c
+++ b/gdb/cuda/cuda-commands.c
@@ -23,6 +23,7 @@
 #include "cli/cli-cmds.h"
 #include "command.h"
 #include "cuda-api.h"
+#include "cuda-asm.h"
 #include "cuda-commands.h"
 #include "cuda-context.h"
 #include "cuda-coord-set.h"
@@ -4049,6 +4050,97 @@ info_cuda_command (const char *arg, int from_tty)
 
 struct cmd_list_element *cudalist;
 
+struct cuda_sass_command_match
+{
+  cuda_module *module;
+  cuda_sass_function_symbol function;
+};
+
+static std::string
+cuda_trim_command_arg (const char *arg)
+{
+  if (arg == nullptr)
+    return std::string ();
+
+  std::string str (arg);
+  const auto start = str.find_first_not_of (" \t\r\n");
+  if (start == std::string::npos)
+    return std::string ();
+
+  const auto end = str.find_last_not_of (" \t\r\n");
+  return str.substr (start, end - start + 1);
+}
+
+static std::vector<cuda_sass_command_match>
+cuda_sass_collect_matches (const std::string &function_name)
+{
+  std::vector<cuda_sass_command_match> matches;
+
+  for (auto &iter : cuda_state::modules ())
+    {
+      cuda_module *module = iter.second.get ();
+      if (module == nullptr || !module->loaded ())
+	continue;
+
+      auto module_matches
+	  = cuda_sass_find_function_symbols (module, function_name);
+      for (const auto &match : module_matches)
+	matches.push_back ({ module, match });
+    }
+
+  return matches;
+}
+
+static void
+cuda_sass_print_ambiguous_matches (
+    const std::string &function_name,
+    const std::vector<cuda_sass_command_match> &matches)
+{
+  gdb_printf (_ ("Multiple SASS functions match '%s':\n"),
+	      function_name.c_str ());
+  for (const auto &match : matches)
+    gdb_printf (_ ("  module 0x%llx %s (%s) at 0x%llx\n"),
+		(unsigned long long) match.module->id (),
+		match.function.display_name.c_str (),
+		match.function.linkage_name.c_str (),
+		(unsigned long long) match.function.entry_pc);
+}
+
+static void
+cuda_sass_command (const char *arg, int from_tty)
+{
+  const std::string function_name = cuda_trim_command_arg (arg);
+  if (function_name.empty ())
+    error (_ ("Missing CUDA kernel/function name."));
+
+  auto matches = cuda_sass_collect_matches (function_name);
+  if (matches.empty ())
+    error (_ ("No loaded SASS function matches '%s'."),
+	   function_name.c_str ());
+  if (matches.size () > 1)
+    {
+      cuda_sass_print_ambiguous_matches (function_name, matches);
+      error (_ ("Ambiguous SASS function '%s'. Use a mangled name or a "
+		"more specific name."),
+	     function_name.c_str ());
+    }
+
+  const auto &match = matches.front ();
+  std::vector<cuda_sass_instruction_record> listing;
+  if (!match.module->disassembler ()->get_function_listing (
+	  match.function.linkage_name, match.function.entry_pc, listing))
+    error (_ ("Could not build SASS listing for '%s'."),
+	   function_name.c_str ());
+
+  gdb_printf (_ ("SASS for %s (%s), module 0x%llx:\n"),
+	      match.function.display_name.c_str (),
+	      match.function.linkage_name.c_str (),
+	      (unsigned long long) match.module->id ());
+  for (const auto &record : listing)
+    gdb_printf ("  [%u] /*%04llx*/ %s\n", record.number,
+		(unsigned long long) record.offset, record.text.c_str ());
+}
+
 void
 cuda_command_switch (const char *switch_string)
 {
@@ -4355,6 +4447,11 @@ _initialize_cuda_commands ()
 
   add_cmd ("thread", no_class, cuda_thread_command,
 	   _ ("Print or select the current CUDA thread."), &cudalist);
+
+  add_cmd ("sass", class_cuda, cuda_sass_command,
+	   _ ("Print a numbered SASS listing for a loaded CUDA "
+	      "kernel/function."),
+	   &cmdlist);
 
   cuda_build_info_cuda_help_message ();
   cmd = add_info ("cuda", info_cuda_command, cuda_info_cmd_help_str.c_str ());

--- a/gdb/cuda/cuda-modules.c
+++ b/gdb/cuda/cuda-modules.c
@@ -123,7 +123,7 @@ cuda_module::disassembler ()
     {
       const auto device = cuda_state::device (m_context->dev_id ());
       m_disassembler = std::make_unique<cuda_module_disassembly_cache> (
-	  device->get_insn_size ());
+	  this, device->get_insn_size ());
     }
 
   return m_disassembler.get ();


### PR DESCRIPTION
## Summary

This patch adds a CUDA-GDB workflow for setting breakpoints on numbered SASS
listings without manually computing runtime device addresses.

New user-facing commands:

```gdb
(cuda-gdb) sass KERNEL
(cuda-gdb) break -sass KERNEL:NUMBER
(cuda-gdb) break -sass KERNEL+OFFSET
```

`sass KERNEL` prints a numbered SASS listing for a loaded CUDA
kernel/function. `break -sass` stores a symbolic SASS breakpoint selector
and resolves it to ordinary CUDA device breakpoint locations when matching CUDA
modules are loaded.

## Motivation

CUDA-GDB can already set source-level CUDA breakpoints and raw address
breakpoints. The missing workflow is a convenient way to break at a visible SASS
instruction. Today users must wait for the kernel/module to load, inspect SASS,
compute a runtime PC or offset manually, and set a raw address breakpoint.

This change keeps the internal breakpoint mechanism address-based while adding
a source-breakpoint-like CLI for SASS listings.

## Implementation Notes

- Extends the CUDA disassembly cache with per-function SASS listing records:
  instruction number, SASS offset, runtime PC, and display text.
- Adds `sass KERNEL` in `gdb/cuda/cuda-commands.c`.
- Adds a CUDA-specific `ordinary_breakpoint` subclass for symbolic SASS
  breakpoints in `gdb/breakpoint.c`.
- Resolves pending SASS breakpoints during normal `breakpoint_re_set()` after
  CUDA module load.
- Uses the existing CUDA device breakpoint insertion and hit-detection path.
- Treats ambiguous matches within one module as an error requiring a more
  specific or mangled function name.

## Validation

Tested on the official `nvidia-gdb-16.3` branch with
`examples/vector_add_debug.cu`.

The branch was built with CUDA 13.3 Debugger headers extracted from the
NVIDIA `cuda-gdb-13-3` package. Runtime smoke tests used CUDA 13.3 `cuobjdump`
and `nvdisasm` extracted from the matching NVIDIA packages.

Build:

```bash
make -j8 all-gdb
```

CLI registration was checked with:

```bash
./gdb/gdb --batch -ex "help sass" -ex "help break"
```

Runtime instruction-number test:

```gdb
(cuda-gdb) break -sass vector_add_kernel:31
(cuda-gdb) run
(cuda-gdb) x/i $pc
```

The breakpoint hit:

```text
<_Z17vector_add_kernelPKfS0_Pfi+480>: S2R R3,SR_TID.X
```

The offset form `break -sass vector_add_kernel+0x1e0` hit the same SASS
instruction.

Listing test:

```gdb
(cuda-gdb) set cuda break_on_launch application
(cuda-gdb) run
(cuda-gdb) sass vector_add_kernel
```

`sass vector_add_kernel` printed a numbered SASS listing and instruction
31 corresponded to offset `0x1e0`.

Additional checks:

- `git diff --check` passes.
- `break -sass vector_add_kernel+0x1e0` can be set before launch, remains
  pending, resolves after CUDA module load, and hits the same instruction as
  `vector_add_kernel:31`.
- `break -sass vector_add_kernel:63` can be set after stopping at kernel entry
  with `set cuda break_on_launch application`, resolves immediately, and hits:

```text
<_Z17vector_add_kernelPKfS0_Pfi+992>: LD.E R8,desc[UR4][R8.64]
```

- A pending `break -sass vector_add_kernel:31` survives `run` a second time and
  resolves again to the current launch's runtime device PC.

## Follow-Up Work

- Add regression tests for:
  - pending SASS breakpoint before launch;
  - immediate resolution after module load;
  - instruction-number form;
  - offset form;
  - ambiguous names;
  - invalid instruction number or offset.
- Consider MI/TUI integration after the CLI semantics settle.
